### PR TITLE
BinarySerializer: Add support to deserialize from IReadOnlyList<byte>

### DIFF
--- a/BinarySerializer.Test/BinarySerializerTests.cs
+++ b/BinarySerializer.Test/BinarySerializerTests.cs
@@ -158,6 +158,33 @@ namespace BinarySerialization.Test
         }
 
         [Fact]
+        public void DeserializeFromReadOnlyListUsingGenericsTest() {
+            var expected = new Iron();
+
+            using (var memoryStream = new MemoryStream())
+            {
+                Serializer.Serialize(memoryStream, expected);
+                var list = memoryStream.ToArray() as IReadOnlyList<byte>;
+
+                var result = Serializer.Deserialize<Iron>(list);
+                Assert.Equal(expected.Formula, result.Formula);
+            }
+        }
+
+        [Fact]
+        public void DeserializeFromReadOnlyListUsingTypeArgument() {
+            var expected = new Iron();
+
+            using (var memoryStream = new MemoryStream()) {
+                Serializer.Serialize(memoryStream, expected);
+                var list = memoryStream.ToArray() as IReadOnlyList<byte>;
+
+                var result = (Iron)Serializer.Deserialize(list, typeof(Iron));
+                Assert.Equal(expected.Formula, result.Formula);
+            }
+        }
+
+        [Fact]
         public void NonSeekableStreamSerializationTest()
         {
             var stream = new NonSeekableStream();

--- a/BinarySerializer.Test/ReadOnlyListStreamTests/EmptyList.cs
+++ b/BinarySerializer.Test/ReadOnlyListStreamTests/EmptyList.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+namespace BinarySerialization.Test.ReadOnlyListStreamTests
+{
+    public class EmptyList : TestBase
+    {
+        [Fact]
+        public void CanSeek()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.True(sut.CanSeek);
+            }
+        }
+
+        [Fact]
+        public void CannotWrite()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.False(sut.CanWrite);
+            }
+        }
+
+        [Fact]
+        public void CannotTimeout()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.False(sut.CanTimeout);
+            }
+        }
+
+        [Fact]
+        public void CanRead()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.True(sut.CanRead);
+            }
+        }
+
+        [Fact]
+        public void IsEmpty()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.Equal(0, sut.Length);
+            }
+        }
+
+        [Fact]
+        public void ReadByteReadsEndOfStream()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.Equal(-1, sut.ReadByte());
+            }
+        }
+
+        [Fact]
+        public void IsAtStartPosition()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.Equal(0, sut.Position);
+            }
+        }
+
+        [Fact]
+        public void DoesNotContainAnyByte()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                var buf = new byte[10];
+                var bytesRead = sut.Read(buf, 0, buf.Length);
+                Assert.Equal(0, bytesRead);
+            }
+        }
+
+        [Fact]
+        public void CannotWriteAnyBytesIntoStream()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                var buf = new byte[] {0x00, 0x01, 0x02};
+                Assert.Throws<ReadOnlyStreamException>(() => sut.Write(buf, 0, buf.Length));
+            }
+        }
+
+        [Fact]
+        public void CanSeekOneByteForward()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                var newPosition = sut.Seek(1, SeekOrigin.Begin);
+                Assert.Equal(1, newPosition);
+            }
+        }
+
+        [Fact]
+        public void CanSetPositionToOne()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                sut.Position = 1;
+            }
+        }
+
+        [Fact]
+        public void SetLengthThrows()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.Throws<NotSupportedException>(() => sut.SetLength(0));
+            }
+        }
+
+        [Fact]
+        public void ThrowsWhenSettingPositionToMinusOne()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.Throws<SeekOutOfRangeException>(() => sut.Position = -1);
+            }
+        }
+
+        [Fact]
+        public void CanSetPositionToZero()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                sut.Position = 0;
+            }
+        }
+
+        [Fact]
+        public void ThrowsWhenSeekBackwardFromBegin()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.Throws<SeekOutOfRangeException>(() => sut.Seek(-1, SeekOrigin.Begin));
+            }
+        }
+
+        [Fact]
+        public void ReadsEndOfStream()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.Equal(-1, sut.ReadByte());
+            }
+        }
+
+        [Fact]
+        public void CanSeekZeroBytesFromBegin()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                var newPosition = sut.Seek(0, SeekOrigin.Begin);
+                Assert.Equal(0, newPosition);
+            }
+        }
+
+        [Fact]
+        public void CanSeekZeroBytesFromEnd()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                var newPosition = sut.Seek(0, SeekOrigin.End);
+                Assert.Equal(0, newPosition);
+            }
+        }
+
+        [Fact]
+        public void CanSeekZeroBytesFromCurrentPosition()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                var newPosition = sut.Seek(0, SeekOrigin.Current);
+                Assert.Equal(0, newPosition);
+            }
+        }
+    }
+}

--- a/BinarySerializer.Test/ReadOnlyListStreamTests/ListWithContent.cs
+++ b/BinarySerializer.Test/ReadOnlyListStreamTests/ListWithContent.cs
@@ -1,0 +1,397 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace BinarySerialization.Test.ReadOnlyListStreamTests
+{
+    public class ListWithContent : TestBase
+    {
+        [Fact]
+        public void CanSeek()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.True(sut.CanSeek);
+            }
+        }
+
+        [Fact]
+        public void CannotWrite()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.False(sut.CanWrite);
+            }
+        }
+
+        [Fact]
+        public void CannotTimeout()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.False(sut.CanTimeout);
+            }
+        }
+
+        [Fact]
+        public void CanRead()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.True(sut.CanRead);
+            }
+        }
+
+        [Fact]
+        public void StreamLengthMatchesListCount()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.Equal(_list.Count, sut.Length);
+            }
+        }
+
+        [Fact]
+        public void IsAtStartPositionAfterCreation()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.Equal(0, sut.Position);
+            }
+        }
+
+        [Fact]
+        public void CanReadAllBytes()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var buf = new byte[256];
+                var bytesRead = sut.Read(buf, 0, buf.Length);
+
+                Assert.Equal(_list.Count, bytesRead);
+                Assert.Equal(_list, buf.Take(bytesRead));
+            }
+        }
+
+        [Fact]
+        public void CannotWriteAnyBytesIntoStream()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var buf = new byte[] {0x00, 0x01, 0x02};
+                Assert.Throws<ReadOnlyStreamException>(() => sut.Write(buf, 0, buf.Length));
+            }
+        }
+
+        [Fact]
+        public void CanSeekBeyondListBondariesFromBegin()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var newPosition = sut.Seek(_list.Count, SeekOrigin.Begin);
+                Assert.Equal(_list.Count, newPosition);
+            }
+        }
+
+        [Fact]
+        public void ReadsEndOfStreamAfterSeekingToListEnd()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Seek(_list.Count, SeekOrigin.Begin);
+                Assert.Equal(-1, sut.ReadByte());
+            }
+        }
+
+        [Fact]
+        public void SetLengthThrows()
+        {
+            using (var sut = new ReadOnlyListStream(_emptyList))
+            {
+                Assert.Throws<NotSupportedException>(() => sut.SetLength(0));
+            }
+        }
+
+        [Fact]
+        public void ReadFirstByteAfterCreation()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.Equal(0, sut.ReadByte());
+            }
+        }
+
+        [Fact]
+        public void ReadsAllBytesInCorrectOrder()
+        {
+            var result = new List<int>();
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                for (var position = 0; position < _list.Count; position++)
+                {
+                    result.Add(sut.ReadByte());
+                }
+            }
+            Assert.Equal(_list.Select(value => (int) value), result);
+        }
+
+        [Fact]
+        public void WritesBytesAtCorrectPositionWhenReadingWithOffset()
+        {
+            var buf = new byte[50];
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Read(buf, 5, 5);
+            }
+            Assert.Equal(
+                new byte[] {
+                    0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x01, 0x02, 0x03, 0x04
+                },
+                buf.Take(10));
+        }
+
+        [Fact]
+        public void ReadsOnlyFiveBytesAfterSeekingFiveBytesForward()
+        {
+            var buf = new byte[50];
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Seek(5, SeekOrigin.Begin);
+                sut.Read(buf, 5, 10);
+            }
+            Assert.Equal(
+                new byte[] {
+                    0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x05, 0x06, 0x07, 0x08, 0x09,
+                    0x00, 0x00, 0x00, 0x00, 0x00
+                },
+                buf.Take(15));
+        }
+
+        [Fact]
+        public void ReadsZeroBytesAfterSeekingTenBytesForward()
+        {
+            var buf = new byte[50];
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Seek(10, SeekOrigin.Begin);
+                Assert.Equal(0, sut.Read(buf, 5, 10));
+            }
+        }
+
+        [Fact]
+        public void ReadsExpectedValueAfterSeekingOneByteForwardFromBegin()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Seek(1, SeekOrigin.Begin);
+                Assert.Equal(1, sut.ReadByte());
+            }
+        }
+
+        [Fact]
+        public void ReadsExpectedValueAfterSeekingOneByteForwardFromCurrent()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Seek(1, SeekOrigin.Current);
+                Assert.Equal(1, sut.ReadByte());
+            }
+        }
+
+        [Fact]
+        public void ReadsExpectedValueAfterSeekingOneByteBackwardFromEnd()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Seek(-1, SeekOrigin.End);
+                Assert.Equal(9, sut.ReadByte());
+            }
+        }
+
+        [Fact]
+        public void CanSetPositionToOne()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Position = 1;
+            }
+        }
+
+        [Fact]
+        public void ThrowsWhenSettingPositionToMinusOne()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.Throws<SeekOutOfRangeException>(() => sut.Position = -1);
+            }
+        }
+
+        [Fact]
+        public void CanSetPositionToZero()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Position = 0;
+            }
+        }
+
+        [Fact]
+        public void HasCorrectPositionAfterSeekingFiveBytesForwardFromBegin()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                sut.Seek(5, SeekOrigin.Begin);
+                Assert.Equal(5, sut.Position);
+            }
+        }
+
+        [Fact]
+        public void HasCorrectPositionAfterReadingFiveBytesFromBegin()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var buf = new byte[10];
+                sut.Read(buf, 0, 5);
+                Assert.Equal(5, sut.Position);
+            }
+        }
+
+        [Fact]
+        public void CanSeekOneByteForwardFromBegin()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var newPosition = sut.Seek(1, SeekOrigin.Begin);
+                Assert.Equal(1, newPosition);
+            }
+        }
+
+        [Fact]
+        public void CanSeekOneByteBackwardFromEnd()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var newPosition = sut.Seek(-1, SeekOrigin.End);
+                Assert.Equal(9, newPosition);
+            }
+        }
+
+        [Fact]
+        public void CanSeekToListEnd()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var newPosition = sut.Seek(0, SeekOrigin.End);
+                Assert.Equal(10, newPosition);
+            }
+        }
+
+        [Fact]
+        public void ThrowsWhenSeekBackwardFromBegin()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.Throws<SeekOutOfRangeException>(() => sut.Seek(-1, SeekOrigin.Begin));
+            }
+        }
+
+        [Fact]
+        public void ThrowsWhenSeekBackwardFromEnd()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                Assert.Throws<SeekOutOfRangeException>(() => sut.Seek(-100, SeekOrigin.End));
+            }
+        }
+
+        [Fact]
+        public void CanSeekZeroBytesFromBegin()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var newPosition = sut.Seek(0, SeekOrigin.Begin);
+                Assert.Equal(0, newPosition);
+            }
+        }
+
+        [Fact]
+        public void CanSeekZeroBytesFromEnd()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var newPosition = sut.Seek(0, SeekOrigin.End);
+                Assert.Equal(_list.Count, newPosition);
+            }
+        }
+
+        [Fact]
+        public void CanSeekZeroBytesFromCurrentPosition()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var newPosition = sut.Seek(0, SeekOrigin.Current);
+                Assert.Equal(0, newPosition);
+            }
+        }
+
+        [Fact]
+        public void ReadsOneByteAfterSeekingToTheLastItem()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var buf = new byte[10];
+                sut.Seek(9, SeekOrigin.Begin);
+                Assert.Equal(1, sut.Read(buf, 0, 10));
+            }
+        }
+
+        [Fact]
+        public void ReadsFiveBytesAfterSeekingToTheSixthItem()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var buf = new byte[10];
+                sut.Seek(5, SeekOrigin.Begin);
+                Assert.Equal(5, sut.Read(buf, 0, 10));
+            }
+        }
+
+        [Fact]
+        public void ReadsFiveBytesInCorrectOrderAfterSeekingToTheSixthItem()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var buf = new byte[10];
+                sut.Seek(5, SeekOrigin.Begin);
+                sut.Read(buf, 0, 10);
+                Assert.Equal(
+                    new byte[] {
+                        0x05, 0x06, 0x07, 0x08, 0x09,
+                        0x00, 0x00, 0x00, 0x00, 0x00
+                    },
+                    buf);
+            }
+        }
+
+        [Fact]
+        public void ReadsFiveBytesInCorrectOrderAfterSettingPositionToTheSixthItem()
+        {
+            using (var sut = new ReadOnlyListStream(_list))
+            {
+                var buf = new byte[10];
+                sut.Position = 5;
+                sut.Read(buf, 0, 10);
+                Assert.Equal(
+                    new byte[] {
+                        0x05, 0x06, 0x07, 0x08, 0x09,
+                        0x00, 0x00, 0x00, 0x00, 0x00
+                    },
+                    buf);
+            }
+        }
+    }
+}

--- a/BinarySerializer.Test/ReadOnlyListStreamTests/TestBase.cs
+++ b/BinarySerializer.Test/ReadOnlyListStreamTests/TestBase.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace BinarySerialization.Test.ReadOnlyListStreamTests
+{
+    public abstract class TestBase
+    {
+        protected readonly IReadOnlyList<byte> _emptyList;
+        protected readonly IReadOnlyList<byte> _list;
+
+        protected TestBase()
+        {
+            _emptyList = new List<byte>();
+
+            _list = new List<byte> {
+                0x00, 0x01, 0x02, 0x03, 0x04,
+                0x05, 0x06, 0x07, 0x08, 0x09
+            };
+        }
+    }
+}

--- a/BinarySerializer/BinarySerializer.cs
+++ b/BinarySerializer/BinarySerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -268,6 +269,18 @@ namespace BinarySerialization
         /// <summary>
         ///     Deserializes the specified stream into an object graph.
         /// </summary>
+        /// <param name="data">The list of bytes from which to deserialize the object graph.</param>
+        /// <param name="type">The type of the root of the object graph.</param>
+        /// <param name="context">An optional serialization context.</param>
+        /// <returns>The deserialized object graph.</returns>
+        public object Deserialize(IReadOnlyList<byte> data, Type type, object context = null) 
+        {
+            return Deserialize(new ReadOnlyListStream(data), type, context);
+        }
+
+        /// <summary>
+        ///     Deserializes the specified stream into an object graph.
+        /// </summary>
         /// <typeparam name="T">The type of the root of the object graph.</typeparam>
         /// <param name="stream">The stream from which to deserialize the object graph.</param>
         /// <param name="context">An optional serialization context.</param>
@@ -287,6 +300,18 @@ namespace BinarySerialization
         public T Deserialize<T>(byte[] data, object context = null)
         {
             return Deserialize<T>(new MemoryStream(data), context);
+        }
+
+        /// <summary>
+        ///     Deserializes the specified stream into an object graph.
+        /// </summary>
+        /// <typeparam name="T">The type of the root of the object graph.</typeparam>
+        /// <param name="data">The list of bytes from which to deserialize the object graph.</param>
+        /// <param name="context">An optional serialization context.</param>
+        /// <returns>The deserialized object graph.</returns>
+        public T Deserialize<T>(IReadOnlyList<byte> data, object context = null)
+        {
+            return (T) Deserialize(data, typeof(T), context);
         }
 
         private RootTypeNode GetGraph(Type valueType)

--- a/BinarySerializer/ReadOnlyListStream.cs
+++ b/BinarySerializer/ReadOnlyListStream.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace BinarySerialization
+{
+    /// <summary>
+    ///    Wraps read only list in stream
+    /// </summary>
+    internal sealed class ReadOnlyListStream : Stream
+    {
+        private const int EndOfStream = -1;
+        private readonly IReadOnlyList<byte> _list;
+        private int _position;
+
+        /// <summary>
+        ///     Creates a stream instance using a read only list as backend.
+        /// </summary>
+        /// <param name="list">A list of bytes the stream should operate on.</param>
+        public ReadOnlyListStream(IReadOnlyList<byte> list)
+        {
+            _list = list ?? throw new ArgumentNullException(nameof(list));
+        }
+
+        public override bool CanTimeout => false;
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => _list.Count;
+
+        public override long Position
+        {
+            get => _position;
+            set => Seek(value, SeekOrigin.Begin);
+        }
+
+        public override void Flush()
+        {
+            // Ignore, stream is read only
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+            if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
+            if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
+
+            if (_position >= _list.Count) return 0;
+
+            var bytesCopied = Math.Max(
+                Math.Min(_list.Count - _position, count),
+                0);
+
+            for (var i = 0; i < bytesCopied; i++)
+                buffer[offset + i] = _list[_position++];
+            return bytesCopied;
+        }
+
+        public override int ReadByte()
+        {
+            return _position >= _list.Count
+                ? EndOfStream
+                : _list[_position++];
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            var startPosition = GetStartPosition(origin);
+
+            var newPosition = startPosition + (int) offset;
+            if (newPosition < 0)
+                ThrowSeekOutOfRangeException(offset, origin);
+
+            return _position = newPosition;
+        }
+
+        private int GetStartPosition(SeekOrigin origin)
+        {
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    return 0;
+                case SeekOrigin.Current:
+                    return _position;
+                case SeekOrigin.End:
+                    return _list.Count;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(origin), origin, null);
+            }
+        }
+
+        private void ThrowSeekOutOfRangeException(long offset, SeekOrigin origin)
+        {
+            var message = $"Invalid seek offset: {offset}, origin: {origin}, current position: {_position}";
+            throw new SeekOutOfRangeException(message);
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new ReadOnlyStreamException();
+        }
+    }
+}

--- a/BinarySerializer/ReadOnlyStreamException.cs
+++ b/BinarySerializer/ReadOnlyStreamException.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+
+namespace BinarySerialization
+{
+    /// <summary>
+    /// Represents an exception that will be thrown due to write access
+    /// </summary>
+    public class ReadOnlyStreamException: IOException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadOnlyStreamException"/> class
+        /// </summary>
+        public ReadOnlyStreamException() 
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadOnlyStreamException"/> class
+        /// </summary>
+        /// <param name="message">A String that describes the error. </param>
+        public ReadOnlyStreamException(string message) : base(message) 
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadOnlyStreamException"/> class
+        /// </summary>
+        /// <param name="message">A String that describes the error.</param>
+        /// <param name="innerException">The inner exception reference.</param>
+        public ReadOnlyStreamException(string message, Exception innerException) : base(message, innerException) 
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadOnlyStreamException"/> class
+        /// </summary>
+        /// <param name="message">A String that describes the error.</param>
+        /// <param name="hresult">An integer identifying the error that has occurred</param>
+        public ReadOnlyStreamException(string message, int hresult) : base(message, hresult) 
+        {
+        }
+    }
+}

--- a/BinarySerializer/SeekOutOfRangeException.cs
+++ b/BinarySerializer/SeekOutOfRangeException.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.IO;
+
+namespace BinarySerialization {
+    /// <summary>
+    /// Represents an exception that will be thrown due to exceeded boundary access
+    /// </summary>
+    public class SeekOutOfRangeException : IOException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SeekOutOfRangeException"/> class
+        /// </summary>
+        public SeekOutOfRangeException() 
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SeekOutOfRangeException"/> class
+        /// </summary>
+        /// <param name="message">A String that describes the error.</param>
+        public SeekOutOfRangeException(string message) : base(message) 
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SeekOutOfRangeException"/> class
+        /// </summary>
+        /// <param name="message">A String that describes the error.</param>
+        /// <param name="innerException">The inner exception reference.</param>
+        public SeekOutOfRangeException(string message, Exception innerException) : base(message, innerException) 
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SeekOutOfRangeException"/> class
+        /// </summary>
+        /// <param name="message">A String that describes the error.</param>
+        /// <param name="hresult">An integer identifying the error that has occurred</param>
+        public SeekOutOfRangeException(string message, int hresult) : base(message, hresult)
+        {
+        }
+    }
+}


### PR DESCRIPTION
- new class ReadOnlyListStream that wraps a IReadOnlyList<byte>
- new method BinarySerializer.Deserialize(IReadOnlyList<byte>, Type, object)