### PR TITLE
Allow the serialization of enums with signed underlying types 

### DIFF
--- a/BinarySerializer.Test/Enums/BaseTypeSignedEnumClass.cs
+++ b/BinarySerializer.Test/Enums/BaseTypeSignedEnumClass.cs
@@ -1,0 +1,6 @@
+﻿namespace BinarySerialization.Test.Enums {
+    public class BaseTypeSignedEnumClass
+    {
+        public BaseTypeSignedEnumValues Field { get; set; }
+    }
+}

--- a/BinarySerializer.Test/Enums/BaseTypeSignedEnumValues.cs
+++ b/BinarySerializer.Test/Enums/BaseTypeSignedEnumValues.cs
@@ -1,0 +1,8 @@
+﻿namespace BinarySerialization.Test.Enums
+{
+    public enum BaseTypeSignedEnumValues : short
+    {
+        PositiveValue = 1,
+        NegativeValue = unchecked ((short)0xFFFF)
+    }
+}

--- a/BinarySerializer.Test/Enums/EnumTests.cs
+++ b/BinarySerializer.Test/Enums/EnumTests.cs
@@ -15,6 +15,15 @@ namespace BinarySerialization.Test.Enums
         }
 
         [Fact]
+        public void BasicSignedEnumTest()
+        {
+            var expected = new BaseTypeSignedEnumClass {Field = BaseTypeSignedEnumValues.NegativeValue};
+            var actual = Roundtrip(expected, sizeof (BaseTypeSignedEnumValues));
+
+            Assert.Equal(expected.Field, actual.Field);
+        }
+
+        [Fact]
         public void EnumAsStringTest()
         {
             var expected = new BaseTypeEnumAsStringClass {Field = BaseTypeEnumValues.B};

--- a/BinarySerializer/TypeExtensions.cs
+++ b/BinarySerializer/TypeExtensions.cs
@@ -52,8 +52,15 @@ namespace BinarySerialization
                 return converter(value);
             }
 
-            if (type.GetTypeInfo().IsEnum && (valueType.GetTypeInfo().IsPrimitive || valueType.GetTypeInfo().IsEnum))
+            if (type.GetTypeInfo().IsEnum && (valueType.GetTypeInfo().IsPrimitive || valueType.GetTypeInfo().IsEnum)) 
             {
+                var underlyingType = Enum.GetUnderlyingType(type);
+
+                if (TypeConverters.TryGetValue(underlyingType, out var c)) 
+                {
+                    return Enum.ToObject(type, c(value));
+                }
+
                 return Enum.ToObject(type, Convert.ToUInt64(value));
             }
 


### PR DESCRIPTION
Does not throw an exception if the underlying Enum type is signed (int, long, short, sbyte) and the value is < 0.