### PR TITLE
Create the FieldPosition attribute

### DIFF
--- a/BinarySerializer.Test/Position/BoundPositionBeginClass.cs
+++ b/BinarySerializer.Test/Position/BoundPositionBeginClass.cs
@@ -1,0 +1,19 @@
+﻿namespace BinarySerialization.Test.Position
+{
+    public class BoundPositionBeginClass
+    {
+        [FieldOrder(0)]
+        public uint FieldOffsetField { get; set; }
+
+        [FieldOrder(1)]
+        [FieldPosition(nameof(FieldOffsetField))]
+        public uint Field { get; set; }
+
+        [FieldOrder(2)]
+        public uint LastUInt { get; set; }
+
+        [FieldOrder(3)]
+        [FieldPosition(0)]
+        public uint RepeatFieldOffsetField { get; set; }
+    }
+}

--- a/BinarySerializer.Test/Position/BoundPositionBeginRewindClass.cs
+++ b/BinarySerializer.Test/Position/BoundPositionBeginRewindClass.cs
@@ -1,0 +1,15 @@
+﻿namespace BinarySerialization.Test.Position
+{
+    public class BoundPositionBeginRewindClass
+    {
+        [FieldOrder(0)]
+        public uint FieldOffsetField { get; set; }
+
+        [FieldOrder(1)]
+        [FieldPosition(nameof(FieldOffsetField), true)]
+        public uint Field { get; set; }
+
+        [FieldOrder(2)]
+        public uint SecondUint { get; set; }
+    }
+}

--- a/BinarySerializer.Test/Position/BoundPositionCurrentClass.cs
+++ b/BinarySerializer.Test/Position/BoundPositionCurrentClass.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+
+namespace BinarySerialization.Test.Position
+{
+    public class BoundPositionCurrentClass
+    {
+        [FieldOrder(0)]
+        public uint FieldOffsetField { get; set; }
+
+        [FieldOrder(1)]
+        [FieldPosition(nameof(FieldOffsetField), SeekOrigin.Current)]
+        public uint Field { get; set; }
+
+        [FieldOrder(2)]
+        public uint LastInt { get; set; }
+    }
+}

--- a/BinarySerializer.Test/Position/BoundPositionJumpyClass.cs
+++ b/BinarySerializer.Test/Position/BoundPositionJumpyClass.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+
+namespace BinarySerialization.Test.Position
+{
+    public class BoundPositionJumpyClass
+    {
+        [FieldOrder(0)]
+        public uint FieldOffsetField1 { get; set; }
+
+        [FieldOrder(1)]
+        [FieldPosition(nameof(FieldOffsetField1))]
+        public uint Field1 { get; set; }
+
+        [FieldOrder(2)]
+        public uint FieldOffsetField2 { get; set; }
+
+        [FieldOrder(3)]
+        [FieldPosition(nameof(FieldOffsetField2))]
+        public uint Field2 { get; set; }
+
+        [FieldOrder(4)]
+        public uint FieldOffsetField3 { get; set; }
+
+        [FieldOrder(5)]
+        [FieldPosition(nameof(FieldOffsetField3), SeekOrigin.Current)]
+        public uint Field3 { get; set; }
+    }
+}

--- a/BinarySerializer.Test/Position/PositionTests.cs
+++ b/BinarySerializer.Test/Position/PositionTests.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinarySerialization.Test.Position
+{
+    [TestClass]
+    public class PositionTests : TestBase
+    {
+        [TestMethod]
+        public void BoundPositionBeginTest()
+        {
+            var expected = new BoundPositionBeginClass { FieldOffsetField = 500, Field = 404, LastUInt = 5, RepeatFieldOffsetField = 500};
+            var actual = Roundtrip(expected, expected.FieldOffsetField + sizeof(uint) + sizeof(uint));
+            Assert.AreEqual(expected.Field, actual.Field);
+            Assert.AreEqual(expected.LastUInt, actual.LastUInt);
+            Assert.AreEqual(expected.FieldOffsetField, actual.RepeatFieldOffsetField);
+        }
+
+        [TestMethod]
+        public void BoundPositionBeginRewindTest()
+        {
+            var expected = new BoundPositionBeginRewindClass { FieldOffsetField = 500, Field = 404, SecondUint = 5 };
+            var actual = Roundtrip(expected, expected.FieldOffsetField + sizeof(uint));
+            Assert.AreEqual(expected.Field, actual.Field);
+            Assert.AreEqual(expected.SecondUint, actual.SecondUint);
+        }
+
+        [TestMethod]
+        public void BoundPositionCurrentTest()
+        {
+            var expected = new BoundPositionCurrentClass { FieldOffsetField = 1, Field = 404, LastInt = 5 };
+            var actual = Roundtrip(expected, sizeof(uint) + expected.FieldOffsetField + sizeof(uint) + sizeof(uint));
+            Assert.AreEqual(expected.Field, actual.Field);
+            Assert.AreEqual(expected.LastInt, actual.LastInt);
+        }
+
+        [TestMethod]
+        public void BoundPositionJumpyTest()
+        {
+            var expected = new BoundPositionJumpyClass { FieldOffsetField1 = 100, Field1 = 104, FieldOffsetField2 = 200, Field2 = 204, FieldOffsetField3 = sizeof(uint), Field3 = 304 };
+            var actual = Roundtrip(expected, expected.FieldOffsetField2 + sizeof(uint) + sizeof(uint) + expected.FieldOffsetField3 + sizeof(uint));
+            Assert.AreEqual(expected.Field1, actual.Field1);
+            Assert.AreEqual(expected.Field2, actual.Field2);
+            Assert.AreEqual(expected.Field3, actual.Field3);
+        }
+    }
+}

--- a/BinarySerializer/FieldOffsetAttribute.cs
+++ b/BinarySerializer/FieldOffsetAttribute.cs
@@ -5,6 +5,7 @@ namespace BinarySerialization
     /// <summary>
     ///     Specifies an absolute offset of a member in the stream.
     /// </summary>
+    [Obsolete("Use FieldPosition with Rewind = true")]
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public sealed class FieldOffsetAttribute : FieldBindingBaseAttribute, IConstAttribute
     {

--- a/BinarySerializer/FieldPositionAttribute.cs
+++ b/BinarySerializer/FieldPositionAttribute.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.IO;
+
+namespace BinarySerialization
+{
+    /// <summary>
+    ///     Specifies an absolute offset of a member in the stream.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class FieldPositionAttribute : FieldBindingBaseAttribute, IConstAttribute
+    {
+        /// <summary>
+        ///     Initializes a new instance of the FieldPosition attribute with a fixed seek.
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <param name="seekOrigin"></param>
+        /// <param name="rewind"></param>
+        public FieldPositionAttribute(ulong offset, SeekOrigin seekOrigin = SeekOrigin.Begin, bool rewind = false)
+        {
+            ConstOffset = offset;
+            SeekOrigin = seekOrigin;
+            Rewind = rewind;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the FieldPosition attribute with a path pointing to a source binding member.
+        /// </summary>
+        /// <param name="path">A path to the source member.</param>
+        /// <param name="seekOrigin"></param>
+        /// <param name="rewind"></param>
+        public FieldPositionAttribute(string path, SeekOrigin seekOrigin = SeekOrigin.Begin, bool rewind = false) : base(path)
+        {
+            SeekOrigin = seekOrigin;
+            Rewind = rewind;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the FieldPosition attribute with a fixed seek position.
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <param name="rewind"></param>
+        /// <param name="seekOrigin"></param>
+        public FieldPositionAttribute(ulong offset, bool rewind, SeekOrigin seekOrigin = SeekOrigin.Begin) : this(offset, seekOrigin, rewind) { }
+
+
+        /// <summary>
+        ///     Initializes a new instance of the FieldPosition attribute with a path pointing to a source binding member.
+        /// </summary>
+        /// <param name="path">A path to the source member.</param>
+        /// <param name="rewind"></param>
+        /// <param name="seekOrigin"></param>
+        public FieldPositionAttribute(string path, bool rewind, SeekOrigin seekOrigin = SeekOrigin.Begin) : this(path, seekOrigin, rewind) { }
+
+        /// <summary>
+        ///     Used to specify fixed member offsets.
+        /// </summary>
+        public ulong ConstOffset { get; set; }
+
+        /// <summary>
+        ///     Get constant value or null if not constant.
+        /// </summary>
+        public object GetConstValue()
+        {
+            return ConstOffset;
+        }
+
+        /// <summary>
+        ///     Specifies the position in a stream to use for seeking the field
+        /// </summary>
+        public SeekOrigin SeekOrigin { get; set; }
+
+        /// <summary>
+        ///     If true it will seek back to position where it was before seek, otherwise stream will continue from the current position
+        /// </summary>
+        public bool Rewind { get; set; }
+    }
+}

--- a/BinarySerializer/Graph/TypeGraph/TypeNode.cs
+++ b/BinarySerializer/Graph/TypeGraph/TypeNode.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -141,6 +142,13 @@ namespace BinarySerialization.Graph.TypeGraph
                 Order = fieldOrderAttribute.Order;
             }
 
+            var positionAttribute = attributes.OfType<FieldPositionAttribute>().SingleOrDefault();
+            if (positionAttribute != null)
+            {
+                PositionSeekOrigin = positionAttribute.SeekOrigin;
+                PositionRewind = positionAttribute.Rewind;
+            }
+
             var serializeAsAttribute = attributes.OfType<SerializeAsAttribute>().SingleOrDefault();
             if (serializeAsAttribute != null)
             {
@@ -176,6 +184,7 @@ namespace BinarySerialization.Graph.TypeGraph
             FieldLengthBindings = GetBindings<FieldLengthAttribute>(attributes);
             FieldBitLengthBindings = GetBindings<FieldBitLengthAttribute>(attributes);
             FieldCountBindings = GetBindings<FieldCountAttribute>(attributes);
+            FieldPositionBindings = GetBindings<FieldPositionAttribute>(attributes);
             FieldOffsetBindings = GetBindings<FieldOffsetAttribute>(attributes);
             FieldScaleBindings = GetBindings<FieldScaleAttribute>(attributes);
             FieldEndiannessBindings = GetBindings<FieldEndiannessAttribute>(attributes);
@@ -322,6 +331,7 @@ namespace BinarySerialization.Graph.TypeGraph
         public BindingCollection FieldBitLengthBindings { get; }
         public BindingCollection ItemLengthBindings { get; }
         public BindingCollection FieldCountBindings { get; }
+        public BindingCollection FieldPositionBindings { get; }
         public BindingCollection FieldOffsetBindings { get; }
         public BindingCollection FieldScaleBindings { get; }
         public BindingCollection LeftFieldAlignmentBindings { get; }
@@ -354,6 +364,9 @@ namespace BinarySerialization.Graph.TypeGraph
         public bool IsIgnored { get; }
 
         public int? Order { get; }
+
+        public SeekOrigin PositionSeekOrigin { get; } = SeekOrigin.Begin;
+        public bool PositionRewind { get; }
 
         public bool AreStringsTerminated { get; }
 

--- a/BinarySerializer/Graph/ValueGraph/ValueNode.cs
+++ b/BinarySerializer/Graph/ValueGraph/ValueNode.cs
@@ -197,9 +197,26 @@ namespace BinarySerialization.Graph.ValueGraph
                     AlignLeft(stream, true);
                 }
 
+                var positionOffset = GetFieldPosition();
                 var offset = GetFieldOffset();
-
-                if (offset != null)
+                if (positionOffset != null)
+                {
+                    if (TypeNode.PositionRewind)
+                    {
+                        using (new StreamResetter(stream))
+                        {
+                            stream.Seek(positionOffset.Value, TypeNode.PositionSeekOrigin);
+                            SerializeInternal(stream, GetConstFieldLength, eventShuttle, measuring);
+                        }
+                    }
+                    else
+                    {
+                        stream.Seek(positionOffset.Value, TypeNode.PositionSeekOrigin);
+                        SerializeInternal(stream, GetConstFieldLength, eventShuttle, measuring);
+                    }
+                    
+                }
+                else if (offset != null)
                 {
                     using (new StreamResetter(stream))
                     {
@@ -211,6 +228,7 @@ namespace BinarySerialization.Graph.ValueGraph
                 {
                     SerializeInternal(stream, GetConstFieldLength, eventShuttle, measuring);
                 }
+
 
                 if (align)
                 {
@@ -251,9 +269,27 @@ namespace BinarySerialization.Graph.ValueGraph
                     AlignLeft(stream, true);
                 }
 
+                var positionOffset = GetFieldPosition();
                 var offset = GetFieldOffset();
-
-                if (offset != null)
+                if (positionOffset != null)
+                {
+                    if (TypeNode.PositionRewind)
+                    {
+                        using (new StreamResetter(stream))
+                        {
+                            stream.Seek(positionOffset.Value, TypeNode.PositionSeekOrigin);
+                            await SerializeInternalAsync(stream, GetConstFieldLength, eventShuttle, cancellationToken)
+                                .ConfigureAwait(false);
+                        }
+                    }
+                    else
+                    {
+                        stream.Seek(positionOffset.Value, TypeNode.PositionSeekOrigin);
+                        await SerializeInternalAsync(stream, GetConstFieldLength, eventShuttle, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+                }
+                else if (offset != null)
                 {
                     using (new StreamResetter(stream))
                     {
@@ -267,6 +303,7 @@ namespace BinarySerialization.Graph.ValueGraph
                     await SerializeInternalAsync(stream, GetConstFieldLength, eventShuttle, cancellationToken)
                         .ConfigureAwait(false);
                 }
+
 
                 if (align)
                 {
@@ -313,10 +350,28 @@ namespace BinarySerialization.Graph.ValueGraph
 
                 AlignLeft(stream);
 
+                var positionOffset = GetFieldPosition();
                 var offset = GetFieldOffset();
-
-                if (offset != null)
+                if (positionOffset != null)
                 {
+                    if (TypeNode.PositionRewind)
+                    {
+                        using (new StreamResetter(stream))
+                        {
+                            stream.Seek(positionOffset.Value, TypeNode.PositionSeekOrigin);
+                            DeserializeInternal(stream, GetFieldLength, eventShuttle);
+                        }
+                    }
+                    else
+                    {
+                        stream.Seek(positionOffset.Value, TypeNode.PositionSeekOrigin);
+                        DeserializeInternal(stream, GetFieldLength, eventShuttle);
+                    }
+
+                }
+                else if (offset != null)
+                {
+
                     using (new StreamResetter(stream))
                     {
                         stream.Position = offset.Value;
@@ -364,9 +419,28 @@ namespace BinarySerialization.Graph.ValueGraph
 
                 AlignLeft(stream);
 
+                var positionOffset = GetFieldPosition();
                 var offset = GetFieldOffset();
+                if (positionOffset != null)
+                {
+                    if (TypeNode.PositionRewind)
+                    {
+                        using (new StreamResetter(stream))
+                        {
+                            stream.Seek(positionOffset.Value, TypeNode.PositionSeekOrigin);
+                            await DeserializeInternalAsync(stream, GetFieldLength, eventShuttle, cancellationToken)
+                                .ConfigureAwait(false);
+                        }
+                    }
+                    else
+                    {
+                        stream.Seek(positionOffset.Value, TypeNode.PositionSeekOrigin);
+                        await DeserializeInternalAsync(stream, GetFieldLength, eventShuttle, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
 
-                if (offset != null)
+                }
+                else if (offset != null)
                 {
                     using (new StreamResetter(stream))
                     {
@@ -523,6 +597,11 @@ namespace BinarySerialization.Graph.ValueGraph
         protected FieldLength GetConstFieldItemLength()
         {
             return GetConstNumericValue(TypeNode.ItemLengthBindings);
+        }
+
+        protected long? GetFieldPosition()
+        {
+            return GetNumericValue(TypeNode.FieldPositionBindings);
         }
 
         protected long? GetFieldOffset()


### PR DESCRIPTION
This pull request implements #178 which allows to jump to addresses and make use of `stream.Seek()` when required.
Since i have files pointing to tables this will help having a master class rather that multiple classes and jump in between.

## Why not improve the FieldOffset instead?

I have tought about that, but that attribute name leads to confusion (at least for me), when I read FieldOffset i always think in offset the stream by a set amount from current position and keep going, instead it is setting the absolute position and reset it position to where it was before.

The `FieldPosition` follows and do exactly what `stream.Seek` do by default and so developer don't need to overthink.

To replicate `FieldOffset` declare as `[FieldPosition(offset, true)]`

## Arguments

- offset|path
- SeekOrigin: Specifies the position in a stream to use for seeking the field
- Rewind: If true it will seek back to position where it was before seek, otherwise stream will continue from the current position

## Example:

```c#
public class FileSpec
{
    [FieldOrder(0)]
    [FieldLength(12)]
    [SerializeAs(SerializedType.TerminatedString)]
    public string FileVersion { get; set; } = "FileMarking";

    [FieldOrder(1)]
    public uint FileVersion { get; set; }

    [FieldOrder(2)]
    public uint HeaderAddress { get; set; }

    [FieldOrder(3)]
    public uint SettingsAddress { get; set; }

    [FieldOrder(4)]
    public uint PreviewAddress { get; set; }

    [FieldOrder(5)]
    public uint LayersAddress { get; set; }

    [FieldOrder(6)]
    [FieldPosition(nameof(HeaderAddress))]
    public uint HeaderField1 { get; set; }

    [FieldOrder(7)]
    public uint HeaderField2 { get; set; }

    [FieldOrder(8)]
    public uint HeaderField3 { get; set; }

    [FieldOrder(9)]
    [FieldPosition(nameof(SettingsAddress))]
    public uint SettingsField1 { get; set; }

    [FieldOrder(10)]
    public uint SettingsField2 { get; set; }

    [FieldOrder(11)]
    [FieldPosition(nameof(PreviewAddress))]
    public uint PreviewSize { get; set; }

    [FieldOrder(12)]
    [FieldCount(nameof(PreviewSize))]
    public byte[] PreviewData {get; set; }

    [FieldOrder(13)]
    [FieldPosition(nameof(LayersAddress))]
    public uint LayerCount { get; set; }

    [FieldOrder(14)]
    [FieldCount(nameof(LayerCount))]
    public Layer[] Layers { get; set; }

    [FieldOrder(15)]
    [FieldPosition(4, SeekOrigin.Current)] // Skip unused 4 bytes first, same as declaring uint Padding
    public uint FileChecksum { get; set; }
}
````

Hope that makes sense :) 