### PR TITLE
Added FieldBitOrder attribute with BitOrder enumeration.

### DIFF
--- a/BinarySerializer.Test/BitOrder/BitOrderClass.cs
+++ b/BinarySerializer.Test/BitOrder/BitOrderClass.cs
@@ -1,0 +1,50 @@
+﻿using BinarySerialization;
+
+namespace BinarySerialization.Test.FieldBitOrder
+{
+    public class BitOrderClass
+    {
+        [FieldOrder(0)]
+        [FieldBitLength(4)]
+        [FieldBitOrder(BitOrder.MsbFirst)]
+        public byte Value1 { get; set; }
+
+        [FieldOrder(1)]
+        [FieldBitLength(4)]
+        [FieldBitOrder(BitOrder.MsbFirst)]
+        public byte Value2 { get; set; }
+    }
+
+    public class CipMessageRouterDataForward
+    {
+        [FieldOrder(0)]
+        [FieldBitLength(1)]
+        [FieldBitOrder(BitOrder.MsbFirst)]
+        public bool Response = false;
+
+        [FieldOrder(1)]
+        [FieldBitLength(7)]
+        [FieldBitOrder(BitOrder.MsbFirst)]
+        public CipServiceCodes Service;
+    }
+
+    public class CipMessageRouterDataBackward
+    {
+        [FieldOrder(0)]
+        [FieldBitLength(7)]
+        public CipServiceCodes Service;
+
+        [FieldOrder(1)]
+        [FieldBitLength(1)]
+        public bool Response = false;
+    }
+
+    public enum CipServiceCodes : byte
+    {
+        GetAttributesAll = 0x01,
+        SetAttributesAllRequest = 0x02,
+        GetAttributeList = 0x03,
+        GetAttributeSingle = 0x0E,
+    }
+
+}

--- a/BinarySerializer.Test/BitOrder/BitOrderTests.cs
+++ b/BinarySerializer.Test/BitOrder/BitOrderTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinarySerialization.Test.FieldBitOrder
+{
+    [TestClass]
+    public class BitOrderTests : TestBase
+    {
+        [TestMethod]
+        public void Test()
+        {
+            var expected = new BitOrderClass
+            {
+                Value1 = 0x7,
+                Value2 = 0x2,
+            };
+
+            var actual = Roundtrip(expected, new byte[] { 0x72 } );
+            Assert.AreEqual(expected.Value1, actual.Value1);
+            Assert.AreEqual(expected.Value2, actual.Value2);
+        }
+
+        [TestMethod]
+        public void TestForward()
+        {
+            var expected = new CipMessageRouterDataForward
+            {
+                Service = CipServiceCodes.GetAttributeSingle,
+                Response = false,
+            };
+
+            var actual = Roundtrip(expected, new byte[] { 0x0E });
+            Assert.AreEqual(expected.Service, actual.Service);
+            Assert.AreEqual(expected.Response, actual.Response);
+        }
+
+        [TestMethod]
+        public void TestBackward()
+        {
+            var expected = new CipMessageRouterDataBackward
+            {
+                Service = CipServiceCodes.GetAttributeSingle,
+                Response = false,
+            };
+
+            var actual = Roundtrip(expected, new byte[] { 0x0E });
+            Assert.AreEqual(expected.Service, actual.Service);
+            Assert.AreEqual(expected.Response, actual.Response);
+        }
+    }
+}

--- a/BinarySerializer/BitOrder.cs
+++ b/BinarySerializer/BitOrder.cs
@@ -1,0 +1,21 @@
+﻿namespace BinarySerialization
+{
+    /// <summary>
+    ///     The order for allocations of bits in Bit Fields.
+    ///     NOTE: This does not re-order bits.  Just determines
+    ///     if they should be retrieved starting from LSB, or MSB
+    ///     of a byte
+    /// </summary>
+    public enum BitOrder
+    {
+        /// <summary>
+        ///     Bit field will start indexed from LSB
+        /// </summary>
+        LsbFirst = 0,
+
+        /// <summary>
+        ///     Bit field will start indexed from MSB
+        /// </summary>
+        MsbFirst = 1,
+    }
+}

--- a/BinarySerializer/BoundedStream.cs
+++ b/BinarySerializer/BoundedStream.cs
@@ -19,7 +19,7 @@ namespace BinarySerialization
 
         private byte _bitBuffer;
 
-        private int _bitOffset;
+        private int _bitBufferCount;
 
         internal BoundedStream(Stream source, string name, Func<FieldLength> maxLengthDelegate = null)
         {
@@ -273,7 +273,7 @@ namespace BinarySerialization
             }
             else
             {
-                if (length.BitCount == 0 && _bitOffset == 0)
+                if (length.BitCount == 0 && _bitBufferCount == 0)
                 {
                     // trivial byte-aligned case
                     WriteByteAligned(buffer, (int) length.ByteCount);
@@ -285,10 +285,10 @@ namespace BinarySerialization
 
                     for (long i = 0; i < lastByteIndex; i++)
                     {
-                        WriteBits(buffer[i], BitsPerByte);
+                        WriteBits(buffer[i], BitsPerByte, length.BitOrder == BitOrder.MsbFirst);
                     }
 
-                    WriteBits(buffer[lastByteIndex], bitCount);
+                    WriteBits(buffer[lastByteIndex], bitCount, length.BitOrder == BitOrder.MsbFirst);
                 }
             }
 
@@ -310,7 +310,7 @@ namespace BinarySerialization
             }
             else
             {
-                if (length.BitCount == 0 && _bitOffset == 0)
+                if (length.BitCount == 0 && _bitBufferCount == 0)
                 {
                     // trivial byte-aligned case, write to underlying stream
                     await WriteByteAlignedAsync(buffer, (int) length.ByteCount, cancellationToken)
@@ -324,11 +324,11 @@ namespace BinarySerialization
                     // collect bits in this, the bottom bounded stream
                     for (long i = 0; i < lastByteIndex; i++)
                     {
-                        await WriteBitsAsync(buffer[i], BitsPerByte, cancellationToken)
+                        await WriteBitsAsync(buffer[i], BitsPerByte, cancellationToken, length.BitOrder == BitOrder.MsbFirst)
                             .ConfigureAwait(false);
                     }
 
-                    await WriteBitsAsync(buffer[lastByteIndex], bitCount, cancellationToken)
+                    await WriteBitsAsync(buffer[lastByteIndex], bitCount, cancellationToken, length.BitOrder == BitOrder.MsbFirst)
                         .ConfigureAwait(false);
                 }
             }
@@ -355,16 +355,17 @@ namespace BinarySerialization
             }
         }
 
-        private void WriteBits(byte value, int count)
+        private void WriteBits(byte value, int count, bool msbFirst)
         {
             var copied = 0;
             while (copied < count)
             {
-                var headroom = BitsPerByte - _bitOffset;
+                var headroom = BitsPerByte - _bitBufferCount;
                 var remaining = count - copied;
                 var copyLength = Math.Min(remaining, headroom);
-                var shift = copied - _bitOffset;
-
+                var shift = msbFirst ?
+                                copied - (BitsPerByte - (copyLength + _bitBufferCount))
+                                : copied - _bitBufferCount;
                 if (shift < 0)
                 {
                     _bitBuffer = (byte)(_bitBuffer | value << -shift);
@@ -374,9 +375,9 @@ namespace BinarySerialization
                     _bitBuffer = (byte)(_bitBuffer | value >> shift);
                 }
 
-                _bitOffset += copyLength;
+                _bitBufferCount += copyLength;
 
-                if (_bitOffset == BitsPerByte)
+                if (_bitBufferCount == BitsPerByte)
                 {
                     FlushBits();
                 }
@@ -390,18 +391,20 @@ namespace BinarySerialization
             var data = new[] { _bitBuffer };
             WriteByteAligned(data, data.Length);
             _bitBuffer = 0;
-            _bitOffset = 0;
+            _bitBufferCount = 0;
         }
 
-        private async Task WriteBitsAsync(byte value, int count, CancellationToken cancellationToken)
+        private async Task WriteBitsAsync(byte value, int count, CancellationToken cancellationToken, bool msbFirst)
         {
             var copied = 0;
             while (copied < count)
             {
-                var headroom = BitsPerByte - _bitOffset;
+                var headroom = BitsPerByte - _bitBufferCount;
                 var remaining = count - copied;
                 var copyLength = Math.Min(remaining, headroom);
-                var shift = copied - _bitOffset;
+                var shift = msbFirst ?
+                                copied - (BitsPerByte - (copyLength + _bitBufferCount))
+                                : copied - _bitBufferCount;
 
                 if (shift < 0)
                 {
@@ -412,9 +415,9 @@ namespace BinarySerialization
                     _bitBuffer = (byte)(_bitBuffer | value >> shift);
                 }
 
-                _bitOffset += copyLength;
+                _bitBufferCount += copyLength;
 
-                if (_bitOffset == BitsPerByte)
+                if (_bitBufferCount == BitsPerByte)
                 {
                     await FlushBitsAsync(cancellationToken).ConfigureAwait(false);
                 }
@@ -428,7 +431,7 @@ namespace BinarySerialization
             var data = new[] { _bitBuffer };
             await WriteByteAlignedAsync(data, data.Length, cancellationToken).ConfigureAwait(false);
             _bitBuffer = 0;
-            _bitOffset = 0;
+            _bitBufferCount = 0;
         }
 
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count,
@@ -466,7 +469,7 @@ namespace BinarySerialization
             }
             else
             {
-                if (length.BitCount == 0 && _bitOffset == 0)
+                if (length.BitCount == 0 && _bitBufferCount == 0)
                 {
                     // trivial byte-aligned case
                     readLength = ReadByteAligned(buffer, (int) length.ByteCount);
@@ -483,14 +486,14 @@ namespace BinarySerialization
 
                     for (long i = 0; i < lastByteIndex; i++)
                     {
-                        readBitCount = ReadBits(BitsPerByte, out value);
+                        readBitCount = ReadBits(BitsPerByte, out value, length.BitOrder==BitOrder.MsbFirst);
                         buffer[i] = value;
-                        readLength += FieldLength.FromBitCount(readBitCount);
+                        readLength += FieldLength.FromBitCount(readBitCount, length.BitOrder);
                     }
 
-                    readBitCount = ReadBits(bitCount, out value);
+                    readBitCount = ReadBits(bitCount, out value, length.BitOrder == BitOrder.MsbFirst);
                     buffer[lastByteIndex] = value;
-                    readLength += FieldLength.FromBitCount(readBitCount);
+                    readLength += FieldLength.FromBitCount(readBitCount, length.BitOrder);
                 }
             }
 
@@ -516,7 +519,7 @@ namespace BinarySerialization
             }
             else
             {
-                if (length.BitCount == 0 && _bitOffset == 0)
+                if (length.BitCount == 0 && _bitBufferCount == 0)
                 {
                     // trivial byte-aligned case
                     readLength = await ReadByteAlignedAsync(buffer, (int) length.ByteCount, cancellationToken)
@@ -534,17 +537,17 @@ namespace BinarySerialization
 
                     for (long i = 0; i < lastByteIndex; i++)
                     {
-                        readBitCount = await ReadBitsAsync(BitsPerByte, value, cancellationToken)
+                        readBitCount = await ReadBitsAsync(BitsPerByte, value, cancellationToken, length.BitOrder == BitOrder.MsbFirst)
                             .ConfigureAwait(false);
 
                         buffer[i] = value[0];
-                        readLength += FieldLength.FromBitCount(readBitCount);
+                        readLength += FieldLength.FromBitCount(readBitCount, length.BitOrder);
                     }
 
                     readBitCount =
-                        await ReadBitsAsync(bitCount, value, cancellationToken).ConfigureAwait(false);
+                        await ReadBitsAsync(bitCount, value, cancellationToken, length.BitOrder == BitOrder.MsbFirst).ConfigureAwait(false);
                     buffer[lastByteIndex] = value[0];
-                    readLength += FieldLength.FromBitCount(readBitCount);
+                    readLength += FieldLength.FromBitCount(readBitCount, length.BitOrder);
                 }
             }
 
@@ -562,23 +565,25 @@ namespace BinarySerialization
             return Source.ReadAsync(buffer, 0, length, cancellationToken);
         }
 
-        private int ReadBits(int count, out byte value)
+        private int ReadBits(int count, out byte value, bool msbFirst)
         {
             byte b = 0;
             var copied = 0;
             while (copied < count)
             {
-                if (_bitOffset == 0)
+                if (_bitBufferCount == 0)
                 {
                     var data = new byte[1];
                     ReadByteAligned(data, data.Length);
                     _bitBuffer = data[0];
-                    _bitOffset = BitsPerByte;
+                    _bitBufferCount = BitsPerByte;
                 }
 
                 var remaining = count - copied;
-                var copyLength = Math.Min(remaining, _bitOffset);
-                var shift = copied - (BitsPerByte - _bitOffset);
+                var copyLength = Math.Min(remaining, _bitBufferCount);
+                var shift = msbFirst ?
+                                copied - (_bitBufferCount - copyLength)
+                                : copied - (BitsPerByte - _bitBufferCount);
 
                 if (shift < 0)
                 {
@@ -589,7 +594,7 @@ namespace BinarySerialization
                     b = (byte)(b | _bitBuffer << shift);
                 }
 
-                _bitOffset -= copyLength;
+                _bitBufferCount -= copyLength;
                 copied += copyLength;
             }
 
@@ -599,23 +604,25 @@ namespace BinarySerialization
             return copied;
         }
 
-        private async Task<int> ReadBitsAsync(int count, byte[] value, CancellationToken cancellationToken)
+        private async Task<int> ReadBitsAsync(int count, byte[] value, CancellationToken cancellationToken, bool msbFirst)
         {
             byte b = 0;
             var copied = 0;
             while (copied < count)
             {
-                if (_bitOffset == 0)
+                if (_bitBufferCount == 0)
                 {
                     var data = new byte[1];
                     await ReadByteAlignedAsync(data, data.Length, cancellationToken).ConfigureAwait(false);
                     _bitBuffer = data[0];
-                    _bitOffset = BitsPerByte;
+                    _bitBufferCount = BitsPerByte;
                 }
 
                 var remaining = count - copied;
-                var copyLength = Math.Min(remaining, _bitOffset);
-                var shift = copied - (BitsPerByte - _bitOffset);
+                var copyLength = Math.Min(remaining, _bitBufferCount);
+                var shift = msbFirst ?
+                                copied - (_bitBufferCount - copyLength)
+                                : copied - (BitsPerByte - _bitBufferCount);
 
                 if (shift < 0)
                 {
@@ -626,7 +633,7 @@ namespace BinarySerialization
                     b = (byte)(b | _bitBuffer << shift);
                 }
 
-                _bitOffset -= copyLength;
+                _bitBufferCount -= copyLength;
                 copied += copyLength;
             }
 

--- a/BinarySerializer/FieldBitOrderAttribute.cs
+++ b/BinarySerializer/FieldBitOrderAttribute.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace BinarySerialization
+{
+    /// <summary>
+    ///     Specifies the bit allocation order of a member or object sub-graph.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
+    public sealed class FieldBitOrderAttribute : FieldBindingBaseAttribute, IBitOrderAttribute, IConstAttribute
+    {
+        /// <summary>
+        ///     Initializes a new instance of the FieldBitOrder class with a constant ordering.
+        /// </summary>
+        /// <param name="bitOrder">The bit order of the decorated member.</param>
+        public FieldBitOrderAttribute(BitOrder bitOrder)
+        {
+            BitOrder = bitOrder;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the FieldBitOrder class with a path pointing to a binding source member.
+        ///     <param name="path">A path to the source member.</param>
+        /// </summary>
+        public FieldBitOrderAttribute(string path) : base(path)
+        {
+        }
+
+        /// <summary>
+        ///     Get constant value or null if not constant.
+        /// </summary>
+        public object GetConstValue()
+        {
+            return BitOrder;
+        }
+
+        /// <summary>
+        ///     The order in which bits are allocated for this member.
+        /// </summary>
+        public BitOrder BitOrder { get; }
+    }
+}

--- a/BinarySerializer/FieldLength.cs
+++ b/BinarySerializer/FieldLength.cs
@@ -9,19 +9,32 @@ namespace BinarySerialization
         public static readonly FieldLength Zero = new FieldLength(0);
         public static readonly FieldLength MaxValue = new FieldLength(long.MaxValue);
 
-        public FieldLength(long byteCount, long bitCount = 0)
+        public FieldLength(long byteCount)
+        {
+            ByteCount = byteCount;
+            BitCount = 0;
+        }
+
+        public FieldLength(int byteCount) : this(Convert.ToInt64(byteCount))
+        {
+        }
+
+        public FieldLength(long byteCount, long bitCount, BitOrder bitOrder)
         {
             ByteCount = byteCount + bitCount / BitsPerByte;
             BitCount = (int) bitCount % BitsPerByte;
+            BitOrder = bitOrder;
         }
 
-        public FieldLength(int byteCount, int bitCount = 0) : this(Convert.ToInt64(byteCount), bitCount)
+        public FieldLength(int byteCount, int bitCount, BitOrder bitOrder) : this(Convert.ToInt64(byteCount), bitCount, bitOrder)
         {
         }
 
         public long ByteCount { get; }
 
         public int BitCount { get; }
+
+        public BitOrder BitOrder { get; }
 
         public long TotalBitCount => ByteCount * BitsPerByte + BitCount;
 
@@ -39,7 +52,8 @@ namespace BinarySerialization
                 return true;
             }
 
-            return ByteCount == other.ByteCount && BitCount == other.BitCount;
+            return ByteCount == other.ByteCount && BitCount == other.BitCount
+                && ((BitOrder == other.BitOrder) || (BitCount==0 || other.BitCount==0));
         }
 
         public override bool Equals(object obj)
@@ -70,9 +84,9 @@ namespace BinarySerialization
             }
         }
 
-        public static FieldLength FromBitCount(int count)
+        public static FieldLength FromBitCount(int count, BitOrder bitOrder)
         {
-            return new FieldLength(0, count);
+            return new FieldLength(0, count, bitOrder);
         }
 
         public static implicit operator FieldLength(long byteCount)
@@ -82,17 +96,17 @@ namespace BinarySerialization
 
         public static FieldLength operator +(FieldLength l1, FieldLength l2)
         {
-            return new FieldLength(l1.ByteCount + l2.ByteCount, l1.BitCount + l2.BitCount);
+            return new FieldLength(l1.ByteCount + l2.ByteCount, l1.BitCount + l2.BitCount, l1.BitOrder);
         }
 
         public static FieldLength operator -(FieldLength l1, FieldLength l2)
         {
-            return FromBitCount((int) (l1.TotalBitCount - l2.TotalBitCount));
+            return FromBitCount((int) (l1.TotalBitCount - l2.TotalBitCount), l1.BitOrder);
         }
 
         public static FieldLength operator %(FieldLength l1, FieldLength l2)
         {
-            return FromBitCount((int) l1.TotalBitCount % (int) l2.TotalBitCount);
+            return FromBitCount((int) l1.TotalBitCount % (int) l2.TotalBitCount, l1.BitOrder);
         }
 
         public static bool operator ==(FieldLength l1, FieldLength l2)

--- a/BinarySerializer/Graph/TypeGraph/TypeNode.cs
+++ b/BinarySerializer/Graph/TypeGraph/TypeNode.cs
@@ -176,6 +176,7 @@ namespace BinarySerialization.Graph.TypeGraph
             // setup bindings
             FieldLengthBindings = GetBindings<FieldLengthAttribute>(attributes);
             FieldBitLengthBindings = GetBindings<FieldBitLengthAttribute>(attributes);
+            FieldBitOrderBindings = GetBindings<FieldBitOrderAttribute>(attributes);
             FieldCountBindings = GetBindings<FieldCountAttribute>(attributes);
             FieldOffsetBindings = GetBindings<FieldOffsetAttribute>(attributes);
             FieldScaleBindings = GetBindings<FieldScaleAttribute>(attributes);
@@ -323,6 +324,7 @@ namespace BinarySerialization.Graph.TypeGraph
 
         public BindingCollection FieldLengthBindings { get; }
         public BindingCollection FieldBitLengthBindings { get; }
+        public BindingCollection FieldBitOrderBindings { get; }
         public BindingCollection ItemLengthBindings { get; }
         public BindingCollection FieldCountBindings { get; }
         public BindingCollection FieldOffsetBindings { get; }

--- a/BinarySerializer/Graph/ValueGraph/ValueNode.cs
+++ b/BinarySerializer/Graph/ValueGraph/ValueNode.cs
@@ -430,9 +430,14 @@ namespace BinarySerialization.Graph.ValueGraph
             }
 
             var bitLength = GetNumericValue(TypeNode.FieldBitLengthBindings);
+            var bitOrder = (BitOrder?)GetNumericValue(TypeNode.FieldBitOrderBindings);
+            if (!bitOrder.HasValue)
+                bitOrder = (BitOrder?)GetConstNumericValue(TypeNode.FieldBitOrderBindings);
+            if (!bitOrder.HasValue)
+                bitOrder = BitOrder.LsbFirst;
             if (bitLength != null)
             {
-                return FieldLength.FromBitCount((int) bitLength);
+                return FieldLength.FromBitCount((int) bitLength, bitOrder.Value);
             }
 
             var parent = Parent;
@@ -461,9 +466,14 @@ namespace BinarySerialization.Graph.ValueGraph
             }
 
             var bitLength = GetConstNumericValue(TypeNode.FieldBitLengthBindings);
+            var bitOrder = (BitOrder?)GetNumericValue(TypeNode.FieldBitOrderBindings);
+            if (!bitOrder.HasValue)
+                bitOrder = (BitOrder?)GetConstNumericValue(TypeNode.FieldBitOrderBindings);
+            if (!bitOrder.HasValue)
+                bitOrder = BitOrder.LsbFirst;
             if (bitLength != null)
             {
-                return FieldLength.FromBitCount((int) bitLength);
+                return FieldLength.FromBitCount((int) bitLength, bitOrder.Value);
             }
 
             return Parent?.GetConstFieldItemLength();

--- a/BinarySerializer/IBitOrderAttribute.cs
+++ b/BinarySerializer/IBitOrderAttribute.cs
@@ -1,0 +1,13 @@
+﻿namespace BinarySerialization
+{
+    /// <summary>
+    ///     Implemented by attributes that support field binding and field bit order binding.
+    /// </summary>
+    internal interface IBitOrderAttribute : IBindableFieldAttribute
+    {
+        /// <summary>
+        ///     The order in which to allocate bits to bit field.  This value will be used if no binding is specified.
+        /// </summary>
+        BitOrder BitOrder { get; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ There are a number of attributes that can be used to control the serialization o
 * [FieldOrder](#fieldorderattribute)
 * [FieldLength](#fieldlengthattribute)
 * [FieldBitLength](#fieldbitlengthattribute)
+* [FieldBitOrder](#fieldbitorderattribute)
 * [FieldCount](#fieldcountattribute)
 * [FieldAlignment](#fieldalignmentattribute)
 * [FieldScale](#fieldscaleattribute)
@@ -252,6 +253,48 @@ public class Header
 
     [FieldOrder(1)]
     [FieldBitLength(5)]
+    public int Length { get; set; }
+}
+```
+
+### FieldBitOrderAttribute ###
+
+The FieldBitOrder attribute is used alongside the FieldBitLength attribute, or bitwise data members.  It determines the order (within the byte) at which the bits are allocated for the field.
+NOTE: It does not change the significance of the bits within the field value, just where in the raw data stream they are allocated to/from.
+
+**WARNING: There are known issues when using bit fields in big endian mode.  Results are undefined.**
+**WARNING: Do NOT mix BitOrder.MsbFirst and BitOrder.LsbFirst within the same byte.  Results are undefined.**
+
+```c#
+
+// This will allocate fields as per:
+// [7..5] => Type
+// [4..0] => Length
+public class HeaderForward
+{
+    [FieldOrder(0)]
+    [FieldBitLength(3)]
+    [FieldBitOrder(BitOrder.MsbFirst)]
+    public HeaderType Type { get; set; }
+
+    [FieldOrder(1)]
+    [FieldBitLength(5)]
+    [FieldBitOrder(BitOrder.MsbFirst)]
+    public int Length { get; set; }
+}
+
+// This will allocate fields as per
+// [0..2] => Type  (default allocation is LsbFirst, so not required for this behaviour)
+// [3..7] => Length
+public class HeaderBackward
+{
+    [FieldOrder(0)]
+    [FieldBitLength(3)]
+    public HeaderType Type { get; set; }
+
+    [FieldOrder(1)]
+    [FieldBitLength(5)]
+    [FieldBitOrder(BitOrder.LsbFirst)]
     public int Length { get; set; }
 }
 ```


### PR DESCRIPTION
Currently these are labelled LsbFirst (0) and MsbFirst (1). If no BitOrder attribute is applied, behaviour is as per LsbFirst, which aligns with the existing behaviour (all current tests pass).

Currently there is no exception thrown for if a byte is used by both an LsbFirst and an MsbFirst field (which I believe should be unsupported operation).  I did attempt to add this, but I couldn't get it working right (it appeared there were LSB writes occuring even though I only had MSB fields defined).  I think these exceptions could be introduced later if necessary (perhaps both MSB and LSB access is a use case for someone).

Fixes #205 