### PR TITLE
Restrict value of FieldBitLength member to stay within its assigned bit length

### DIFF
--- a/BinarySerializer.Test/BitLength/BitLengthClass.cs
+++ b/BinarySerializer.Test/BitLength/BitLengthClass.cs
@@ -21,6 +21,6 @@ namespace BinarySerialization.Test.BitLength
 
         [FieldOrder(4)]
         [FieldBitLength(8)]
-        public InternalBitLengthClass Internal2 { get; set; }
+        public InternalBitLengthValueClass Internal2 { get; set; }
     }
 }

--- a/BinarySerializer.Test/BitLength/BitLengthOverflowClass.cs
+++ b/BinarySerializer.Test/BitLength/BitLengthOverflowClass.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BinarySerialization.Test.BitLength
+{
+    public class BitLengthOverflowLsbClass
+    {
+        [FieldOrder(0)]
+        [FieldBitLength(2)]
+        public int Value;
+
+        [FieldOrder(1)]
+        [FieldBitLength(4)]
+        public int Value2;
+
+        [FieldOrder(2)]
+        [FieldBitLength(2)]
+        public int Value3;
+    }
+
+    public class BitLengthOverflowMsbClass
+    {
+        [FieldOrder(0)]
+        [FieldBitLength(2)]
+        [FieldBitOrder(BitOrder.MsbFirst)]
+        public int Value;
+
+        [FieldOrder(1)]
+        [FieldBitLength(4)]
+        [FieldBitOrder(BitOrder.MsbFirst)]
+        public int Value2;
+
+        [FieldOrder(2)]
+        [FieldBitLength(2)]
+        [FieldBitOrder(BitOrder.MsbFirst)]
+        public int Value3;
+    }
+}

--- a/BinarySerializer.Test/BitLength/BitLengthTests.cs
+++ b/BinarySerializer.Test/BitLength/BitLengthTests.cs
@@ -16,15 +16,59 @@ namespace BinarySerialization.Test.BitLength
                 B = 0b111,
                 C = (TypeCode) 0b1101,
                 Internal = new InternalBitLengthClass {Value = 0b1111},
-                Internal2 = new InternalBitLengthClass {Value = 0b10101010}
+                Internal2 = new InternalBitLengthValueClass {Value = 0b1010, Value2 = 0b0101}
             };
 
-            var actual = Roundtrip(expected, new byte[] {0x7d, 0xef, 0xf6, 0xfd, 0xaa});
+            var actual = Roundtrip(expected, new byte[] {0x7d, 0xef, 0xf6, 0xfd, 0x5a});
             Assert.AreEqual(expected.A, actual.A);
             Assert.AreEqual(expected.B, actual.B);
             Assert.AreEqual(expected.C, actual.C);
             Assert.AreEqual(expected.Internal.Value, actual.Internal.Value);
             Assert.AreEqual(0b1010, actual.Internal2.Value);
+        }
+
+        [TestMethod]
+        public void LengthOverrunTest()
+        {
+            var expectedHighBits = new InternalBitLengthValueClass
+            {
+                Value = 0,
+                Value2 = 0x7FFFFFFF,
+            };
+            var actualHighBits = Roundtrip(expectedHighBits, new byte[] { 0xF0 });
+            Assert.AreEqual(expectedHighBits.Value & 0x0F, actualHighBits.Value);
+            Assert.AreEqual(expectedHighBits.Value2 & 0x0F, actualHighBits.Value2);
+
+            var expectedLowBits = new InternalBitLengthValueClass
+            {
+                Value = 0x7FFFFFFF,
+                Value2 = 0,
+            };
+            var actualLowBits = Roundtrip(expectedLowBits, new byte[] { 0x0F });
+            Assert.AreEqual(expectedLowBits.Value & 0x0F, actualLowBits.Value);
+            Assert.AreEqual(expectedLowBits.Value2 & 0x0F, actualLowBits.Value2);
+
+            var expectedLsbBits = new BitLengthOverflowLsbClass
+            {
+                Value = 0b1_01,
+                Value2 = 0b10_1101,
+                Value3 = 0b1_10
+            };
+            var actualLsbBits = Roundtrip(expectedLsbBits, new byte[] { 0b1011_0101 });
+            Assert.AreEqual(expectedLsbBits.Value  & 0b11, actualLsbBits.Value);
+            Assert.AreEqual(expectedLsbBits.Value2 & 0b1111, actualLsbBits.Value2);
+            Assert.AreEqual(expectedLsbBits.Value3 & 0b11, actualLsbBits.Value3);
+
+            var expectedMsbBits = new BitLengthOverflowMsbClass
+            {
+                Value = 0b101,
+                Value2 = 0b101101,
+                Value3 = 0b110
+            };
+            var actualMsbBits = Roundtrip(expectedLsbBits, new byte[] { 0b1011_0101 });
+            Assert.AreEqual(expectedMsbBits.Value & 0b11, actualMsbBits.Value);
+            Assert.AreEqual(expectedMsbBits.Value2 & 0b1111, actualMsbBits.Value2);
+            Assert.AreEqual(expectedMsbBits.Value3 & 0b11, actualMsbBits.Value3);
         }
 
         //[TestMethod]
@@ -36,10 +80,10 @@ namespace BinarySerialization.Test.BitLength
                 B = 0b111,
                 C = (TypeCode)0b1101,
                 Internal = new InternalBitLengthClass { Value = 0b1111 },
-                Internal2 = new InternalBitLengthClass { Value = 0b10101010 }
+                Internal2 = new InternalBitLengthValueClass { Value = 0b1010, Value2 = 0b0101 }
             };
 
-            var actual = RoundtripBigEndian(expected, new byte[] { 0x7d, 0xef, 0xf6, 0xfd, 0xaa });
+            var actual = RoundtripBigEndian(expected, new byte[] { 0x7d, 0xef, 0xf6, 0xfd, 0x5a });
             Assert.AreEqual(expected.A, actual.A);
             Assert.AreEqual(expected.B, actual.B);
             Assert.AreEqual(expected.C, actual.C);

--- a/BinarySerializer/BoundedStream.cs
+++ b/BinarySerializer/BoundedStream.cs
@@ -362,17 +362,19 @@ namespace BinarySerialization
             {
                 var headroom = BitsPerByte - _bitBufferCount;
                 var remaining = count - copied;
+                byte mask = (byte) (((1 << count) - 1) ^ ((1 << copied) -1)); // generate bit mask for all bits within [count..copied]
                 var copyLength = Math.Min(remaining, headroom);
                 var shift = msbFirst ?
                                 copied - (BitsPerByte - (copyLength + _bitBufferCount))
                                 : copied - _bitBufferCount;
+
                 if (shift < 0)
                 {
-                    _bitBuffer = (byte)(_bitBuffer | value << -shift);
+                    _bitBuffer = (byte)(_bitBuffer | (value & mask) << -shift);
                 }
                 else
                 {
-                    _bitBuffer = (byte)(_bitBuffer | value >> shift);
+                    _bitBuffer = (byte)(_bitBuffer | (value & mask) >> shift);
                 }
 
                 _bitBufferCount += copyLength;
@@ -401,6 +403,7 @@ namespace BinarySerialization
             {
                 var headroom = BitsPerByte - _bitBufferCount;
                 var remaining = count - copied;
+                byte mask = (byte)(((1 << count) - 1) ^ ((1 << copied) - 1)); // generate bit mask for all bits below 1<<count
                 var copyLength = Math.Min(remaining, headroom);
                 var shift = msbFirst ?
                                 copied - (BitsPerByte - (copyLength + _bitBufferCount))
@@ -408,11 +411,11 @@ namespace BinarySerialization
 
                 if (shift < 0)
                 {
-                    _bitBuffer = (byte)(_bitBuffer | value << -shift);
+                    _bitBuffer = (byte)(_bitBuffer | (value & mask) << -shift);
                 }
                 else
                 {
-                    _bitBuffer = (byte)(_bitBuffer | value >> shift);
+                    _bitBuffer = (byte)(_bitBuffer | (value & mask) >> shift);
                 }
 
                 _bitBufferCount += copyLength;


### PR DESCRIPTION
Currently if a FieldBitLength attribute is applied which indicates <8
bits of data for a field, but it is defined of a type >=8 bits, it is
possible to assign it a value which won't fit in the assigned bit length.
This results in it overflowing to adjacent fields (only upwards in the
byte).  This can however cause 'corruption' in other fields.

Added:
- bit masking on the BoundedStream 'sub-byte' writes
- new test case to specifically check for this
- alteration to existing test case which appeared to expect this
   behaviour.  Perhaps this previous behaviour was desirable, although I
   couldn't see logic that would 'expand' a childs field bit length based
   upon a parents field bit length (so perhaps an error in the original
   test case?)

Fixes #209 

Signed-off-by: Bevan Weiss <bevan.weiss@gmail.com>