### PR TITLE
Clean up warnings, and upgrade a few NuGet packages

### DIFF
--- a/BinarySerializer.Performance/BinarySerializer.Performance.csproj
+++ b/BinarySerializer.Performance/BinarySerializer.Performance.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/BinarySerializer.Test/BinarySerializer.Test.csproj
+++ b/BinarySerializer.Test/BinarySerializer.Test.csproj
@@ -22,10 +22,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BinarySerializer\BinarySerializer.csproj" />

--- a/BinarySerializer.Test/WhenNot/WhenNotClass.cs
+++ b/BinarySerializer.Test/WhenNot/WhenNotClass.cs
@@ -6,7 +6,9 @@
         public bool ExcludeValue { get; set; }
 
         [FieldOrder(1)]
+#pragma warning disable 612, 618
         [SerializeWhenNot(nameof(ExcludeValue), true)]
+#pragma warning restore 612, 618
         public int Value { get; set; }
     }
 }

--- a/BinarySerializer/BinarySerializer.csproj
+++ b/BinarySerializer/BinarySerializer.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -44,7 +44,7 @@
     <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />


### PR DESCRIPTION
- Added pragma to SerializeWhenNot test case usage to suppress warning
- Upgraded Performance project framework from netcore v2->v3.1 to avoid warning on deprecation
- Rolled back v7 Encoding to v6 to avoid warning about netcore v3.1
- Updated Test.SDK from v17.5->v17.6
- Updated GitHub sourcelink NuGet from v1.0.0->v1.1.1
- Updated TypeExtension from v4.5.1->v4.7.0

All Test Cases pass.