### PR TITLE
Add new SerializeAs option for TerminatedSizedString.

### DIFF
--- a/BinarySerializer.Test/SerializeAs/SerializeAsTest.cs
+++ b/BinarySerializer.Test/SerializeAs/SerializeAsTest.cs
@@ -50,5 +50,24 @@ namespace BinarySerialization.Test.SerializeAs
             var actualItems = actual.Items.Select(i => i.Trim()).ToList();
             CollectionAssert.AreEqual(expected.Items, actualItems);
         }
+
+        [TestMethod]
+        public void SerializeAsTerminatedStringWithPadding()
+        {
+            var expected = new TerminatedSizedStringClass { Value = "hi" };
+            var actual = Roundtrip(expected, new byte[] { 0x68, 0x69, 0x0A, 0x0D, 0x0D });
+
+            Assert.AreEqual(expected.Value, actual.Value);
+        }
+
+        [TestMethod]
+        public void SerializeAsTerminatedStringWithTruncation()
+        {
+            var expected = new TerminatedSizedStringClass { Value = "hi test" };
+            var actual = Roundtrip(expected, new byte[] { 0x68, 0x69, 0x20, 0x74, 0x0A });
+
+            // we expect to have truncated to only have 4 characters (and the terminator)
+            Assert.AreEqual(expected.Value.Substring(0,4), actual.Value);
+        }
     }
 }

--- a/BinarySerializer.Test/SerializeAs/TerminatedSizedStringClass.cs
+++ b/BinarySerializer.Test/SerializeAs/TerminatedSizedStringClass.cs
@@ -1,0 +1,9 @@
+﻿namespace BinarySerialization.Test.SerializeAs
+{
+    class TerminatedSizedStringClass
+    {
+        [FieldLength(5)]
+        [SerializeAs(SerializedType.TerminatedSizedString, StringTerminator = '\n', PaddingValue = 0x0D)]
+        public string Value { get; set; }
+    }
+}

--- a/BinarySerializer/Graph/TypeGraph/EnumTypeNode.cs
+++ b/BinarySerializer/Graph/TypeGraph/EnumTypeNode.cs
@@ -46,7 +46,8 @@ namespace BinarySerialization.Graph.TypeGraph
             if (enumAttributes.Any(enumAttribute => enumAttribute.Value != null) ||
                 serializedType == SerializedType.TerminatedString ||
                 serializedType == SerializedType.SizedString ||
-                serializedType == SerializedType.LengthPrefixedString)
+                serializedType == SerializedType.LengthPrefixedString ||
+                serializedType == SerializedType.TerminatedSizedString)
             {
                 EnumInfo.EnumValues = enumAttributes.ToDictionary(enumAttribute => enumAttribute.Key,
                     enumAttribute =>

--- a/BinarySerializer/Graph/TypeGraph/TypeNode.cs
+++ b/BinarySerializer/Graph/TypeGraph/TypeNode.cs
@@ -48,6 +48,7 @@ namespace BinarySerialization.Graph.TypeGraph
                 {SerializedType.TerminatedString, default(string)},
                 {SerializedType.SizedString, default(string)},
                 {SerializedType.LengthPrefixedString, default(string)},
+                {SerializedType.TerminatedSizedString, default(string)},
                 {SerializedType.ByteArray, default(byte[])}
             };
 
@@ -154,7 +155,8 @@ namespace BinarySerialization.Graph.TypeGraph
                 }
 #pragma warning restore 618
 
-                if (_serializedType.Value == SerializedType.TerminatedString)
+                if (_serializedType.Value == SerializedType.TerminatedString ||
+                    _serializedType.Value == SerializedType.TerminatedSizedString)
                 {
                     AreStringsTerminated = true;
                     StringTerminator = serializeAsAttribute.StringTerminator;
@@ -170,7 +172,8 @@ namespace BinarySerialization.Graph.TypeGraph
                 IsNullable = serializedType == SerializedType.Default ||
                              serializedType == SerializedType.ByteArray ||
                              serializedType == SerializedType.TerminatedString ||
-                             serializedType == SerializedType.SizedString;
+                             serializedType == SerializedType.SizedString ||
+                             serializedType == SerializedType.TerminatedSizedString;
             }
             
             // setup bindings

--- a/BinarySerializer/SerializedType.cs
+++ b/BinarySerializer/SerializedType.cs
@@ -90,6 +90,12 @@ namespace BinarySerialization
         /// <summary>
         ///     An encoded string prefixed with a LEB128-encoded length.  This is equivalent to how BinaryWriter encodes a string.
         /// </summary>
-        LengthPrefixedString
+        LengthPrefixedString,
+
+        /// <summary>
+        ///     An encoded string with a terminator, which is null (zero) by default or can be specified by setting StringTerminator.
+        ///     Also has a maximum length storage available
+        /// </summary>
+        TerminatedSizedString,
     }
 }


### PR DESCRIPTION
This allows to keep the existing TerminatedString behaviour when a field length constraint is applied, where it essentially becomes a SizedString. Whilst also allowing new behaviour that would keep the terminated string aspect, but truncate / pad the terminated string around the length constraint

Test case shows non-standard terminator (\n or 0x0A), and non-standard padding byte 0x0D just to prove that these work as expected also.

Possibly fixes #171 (confirmation required)