### PR TITLE
Add code-coverage

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,18 +8,44 @@ on:
 
 jobs:
   build:
-
-    runs-on: windows-latest
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    name: CI Build
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 3.1.101
+
     - name: Install dependencies
       run: dotnet restore
+
     - name: Build
       run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+
+    - name: Test (inc Code Coverage)
+      run: dotnet test --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+    - name: Code Coverage Report
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: coverage/**/coverage.cobertura.xml
+        badge: true
+        fail_below_min: true
+        format: markdown
+        hide_branch_rate: false
+        hide_complexity: true
+        indicators: true
+        output: both
+        thresholds: '60 80'
+
+#    - name: Add Coverage PR Comment
+#      uses: marocchino/sticky-pull-request-comment@v2
+#      if: github.event_name == 'pull_request'
+#      with:
+#        recreate: true
+#        path: code-coverage-results.md

--- a/BinarySerializer.Test/BinarySerializer.Test.csproj
+++ b/BinarySerializer.Test/BinarySerializer.Test.csproj
@@ -22,9 +22,17 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/BinarySerializer.Test/Issues/Issue94/Issue94Tests.cs
+++ b/BinarySerializer.Test/Issues/Issue94/Issue94Tests.cs
@@ -26,7 +26,8 @@ namespace BinarySerialization.Test.Issues.Issue94
         [TestMethod]
         public void Test()
         {
-            using (var file = new FileStream(@"Issues\Issue94\tst.file", FileMode.Open, FileAccess.Read))
+            string path = Path.Combine("Issues", "Issue94", "tst.file");
+            using (var file = new FileStream(path, FileMode.Open, FileAccess.Read))
             {
                 var db = Deserialize<MainClass>(file);
             }

--- a/BinarySerializer.Test/Value/PngTests.cs
+++ b/BinarySerializer.Test/Value/PngTests.cs
@@ -9,7 +9,8 @@ namespace BinarySerialization.Test.Value
         [TestMethod]
         public void DeserializePng()
         {
-            using (var stream = new FileStream("Value\\image.png", FileMode.Open, FileAccess.Read))
+            string path = Path.Combine("Value", "image.png");
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
             {
                 var data = new byte[stream.Length];
                 stream.Read(data, 0, data.Length);


### PR DESCRIPTION
Add code coverage metrics on pull requests.

The irongut action requires docker, hence the change to Ubuntu runner.
When executing against the Ubuntu running the two test cases failed due to path separate '\' instead of '/', so used Path.Combine to make this platform agnostic.

It might be worth having another job for test execution under Windows also, although I think this would only really capture issues with test logic (like the path delimiter issue above).
Another possibility might be to have an Ubuntu docker QEMU instance emulation of a Big Endian architecture to potentially test for issues around Big/Little endian logic (in regards to execution platform).