### PR TITLE
Make top-level serialization context accessible to custom serializers

### DIFF
--- a/BinarySerializer.Test/Custom/CustomTests.cs
+++ b/BinarySerializer.Test/Custom/CustomTests.cs
@@ -28,11 +28,12 @@ namespace BinarySerialization.Test.Custom
         public void CustomWithContextTest()
         {
             var expected = new CustomWithContextContainerClass {Value = new CustomWithContextClass()};
+            var context = new CustomWithContextContainerContextClass { Value = "context" };
 
             var serializer = new BinarySerializer();
             var stream = new MemoryStream();
 
-            serializer.Serialize(stream, expected, "context");
+            serializer.Serialize(stream, expected, context);
             stream.Position = 0;
             serializer.Deserialize<CustomWithContextContainerClass>(stream);
         }

--- a/BinarySerializer.Test/Custom/CustomWithContextClass.cs
+++ b/BinarySerializer.Test/Custom/CustomWithContextClass.cs
@@ -9,8 +9,10 @@ namespace BinarySerialization.Test.Custom
             BinarySerializationContext serializationContext)
         {
             Assert.AreEqual(typeof(CustomWithContextContainerClass), serializationContext.ParentType);
-            //Assert.AreEqual("context", serializationContext.ParentContext.ParentValue);
-            // TODO check root context
+
+
+            Assert.AreEqual(typeof(CustomWithContextContainerContextClass), serializationContext.ParentContext.ParentContext.ParentType);
+            Assert.AreEqual("context", (serializationContext.ParentContext.ParentContext.ParentValue as CustomWithContextContainerContextClass).Value);
         }
 
         public void Deserialize(Stream stream, BinarySerialization.Endianness endianness,

--- a/BinarySerializer.Test/Custom/CustomWithContextContainerContextClass.cs
+++ b/BinarySerializer.Test/Custom/CustomWithContextContainerContextClass.cs
@@ -1,0 +1,7 @@
+namespace BinarySerialization.Test.Custom
+{
+    public class CustomWithContextContainerContextClass
+    {
+        public string Value { get; set; }
+    }
+}

--- a/BinarySerializer/Graph/ValueGraph/RootValueNode.cs
+++ b/BinarySerializer/Graph/ValueGraph/RootValueNode.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -99,6 +100,13 @@ namespace BinarySerialization.Graph.ValueGraph
         protected override Encoding GetFieldEncoding()
         {
             return EncodingCallback();
+        }
+
+        protected override BinarySerializationContext CreateSerializationContext()
+        {
+            var parent = Children.FirstOrDefault()?.Parent;
+            return new BinarySerializationContext(Value, parent?.Value, parent?.TypeNode.Type,
+                null, TypeNode.MemberInfo);
         }
 
         private static RootTypeNode GetContextGraph(Type valueType)

--- a/BinarySerializer/Graph/ValueGraph/ValueNode.cs
+++ b/BinarySerializer/Graph/ValueGraph/ValueNode.cs
@@ -960,7 +960,7 @@ namespace BinarySerialization.Graph.ValueGraph
             return Convert.ToInt64(binding.ConstValue);
         }
 
-        private BinarySerializationContext CreateSerializationContext()
+        protected virtual BinarySerializationContext CreateSerializationContext()
         {
             var parent = Parent;
             return new BinarySerializationContext(Value, parent?.Value, parent?.TypeNode.Type,


### PR DESCRIPTION
This fixes #229 where the optional serialization context is not accessible to BinarySerializationContext tree when working with an IBinarySerializable class.

I think it's a little quirky that when traversing up the SerializationContext tree there are two BinarySerializationContext nodes with the same value (the root), and now the optional context above that, but this preserves the existing behavior of the framework. 

I also noticed that passing in a primitive type like a string for the optional context will not save the context into the RootValueNode, as it only looks for children objects, but that's out of scope for the issue I was facing.

I have no idea if I've solved the problem in a correct way, but it works for my use case. I'm newer to the library side of things, does changing CreateSerializationContext from private to protected virtual count as a breaking change?