### PR TITLE
WIP: #180 Additional serializer infinityLoop when using FieldBitLength [3 Unit tests broken]

### DIFF
--- a/BinarySerializer/Graph/ValueGraph/ValueNode.cs
+++ b/BinarySerializer/Graph/ValueGraph/ValueNode.cs
@@ -315,6 +315,11 @@ namespace BinarySerialization.Graph.ValueGraph
                     return;
                 }
 
+                if (stream.AvailableForReading < 0)
+                {
+                    throw new Exception("Read passed end of stream, binary message does not fit the provided type.");
+                }
+
                 AlignLeft(stream);
 
                 var offset = GetFieldOffset();


### PR DESCRIPTION
Ref to #180 

Infinity loop occurs when trying to parse a binary message that does not fit into the provided type.

This commit adds an additional check when parsing to throw exception if stream.AvailableForReading < 0.

This commit breaks following unit tests:
- Issue55Tests
- ImmutableTest2
- IOExceptionTest - ShouldThrowIOExceptionNotInvalidOperationExceptionTest